### PR TITLE
Use Class for Initializer return types

### DIFF
--- a/ticktock-android/lazyzonerules-startup/src/main/java/dev/zacsweers/ticktock/android/lazyzonerules/startup/AndroidLazyZoneRulesInitializer.java
+++ b/ticktock-android/lazyzonerules-startup/src/main/java/dev/zacsweers/ticktock/android/lazyzonerules/startup/AndroidLazyZoneRulesInitializer.java
@@ -6,11 +6,11 @@ import dev.zacsweers.ticktock.android.lazyzonerules.AndroidLazyZoneRules;
 import java.util.Collections;
 import java.util.List;
 
-class AndroidLazyZoneRulesInitializer implements Initializer<AndroidLazyZoneRulesInitializer> {
+class AndroidLazyZoneRulesInitializer implements Initializer<Class<AndroidLazyZoneRulesInitializer>> {
 
-  @Override public AndroidLazyZoneRulesInitializer create(Context context) {
+  @Override public Class<AndroidLazyZoneRulesInitializer> create(Context context) {
     AndroidLazyZoneRules.init(context);
-    return this;
+    return AndroidLazyZoneRulesInitializer.class;
   }
 
   @Override public List<Class<? extends Initializer<?>>> dependencies() {

--- a/ticktock-android/tzdb-startup/src/main/java/dev/zacsweers/ticktock/android/tzdb/startup/AndroidTzdbRulesInitializer.java
+++ b/ticktock-android/tzdb-startup/src/main/java/dev/zacsweers/ticktock/android/tzdb/startup/AndroidTzdbRulesInitializer.java
@@ -6,11 +6,11 @@ import dev.zacsweers.ticktock.android.tzdb.AndroidTzdbZoneRules;
 import java.util.Collections;
 import java.util.List;
 
-class AndroidTzdbRulesInitializer implements Initializer<AndroidTzdbRulesInitializer> {
+class AndroidTzdbRulesInitializer implements Initializer<Class<AndroidTzdbRulesInitializer>> {
 
-  @Override public AndroidTzdbRulesInitializer create(Context context) {
+  @Override public Class<AndroidTzdbRulesInitializer> create(Context context) {
     AndroidTzdbZoneRules.init(context);
-    return this;
+    return AndroidTzdbRulesInitializer.class;
   }
 
   @Override public List<Class<? extends Initializer<?>>> dependencies() {


### PR DESCRIPTION
We have no actual return type, so this seems like a reasonable/better option than keeping the instance