### PR TITLE
add script to download and set up Android SDK

### DIFF
--- a/.github/android-sdk.sh
+++ b/.github/android-sdk.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# The default android version ENV is a mess on GH Actions, so just install it ourselves.
+# Adapted workaround from https://github.com/actions/virtual-environments/issues/60
+
+echo "Setting up Actions Android SDK"
+
+echo "Installing sdkmanager"
+wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}.zip
+# unpacking into cmdline-tools/ because of https://issuetracker.google.com/issues/150942306
+mkdir -p $ANDROID_HOME/cmdline-tools/
+unzip -o android-sdk.zip -d $ANDROID_HOME/cmdline-tools
+# rename folder to latest to match Android Studio/sdkmanager behavior
+mv $ANDROID_HOME/cmdline-tools/tools $ANDROID_HOME/cmdline-tools/latest
+
+echo "Installing required Android tools"
+echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
+
+echo "Done!"

--- a/.github/android-sdk.sh
+++ b/.github/android-sdk.sh
@@ -16,5 +16,6 @@ mv $ANDROID_HOME/cmdline-tools/tools $ANDROID_HOME/cmdline-tools/latest
 
 echo "Installing required Android tools"
 echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
+echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "patcher;v4"
 
 echo "Done!"

--- a/.github/android-sdk.sh
+++ b/.github/android-sdk.sh
@@ -16,6 +16,7 @@ mv $ANDROID_HOME/cmdline-tools/tools $ANDROID_HOME/cmdline-tools/latest
 
 echo "Installing required Android tools"
 echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
+# without manually installing this the license check in AGP fails https://issuetracker.google.com/issues/160361319
 echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "patcher;v4"
 
 echo "Done!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push]
 
+env:
+  ANDROID_HOME: "/home/runner/tools/android-sdk"
+  ANDROID_SDK_TOOLS: "6514223_latest"
+
 jobs:
   build:
     name: JDK ${{ matrix.java_version }}
@@ -17,6 +21,8 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java_version }}
+    - name: Install Android SDK
+      run: ./.github/android-sdk.sh
     - name: Configure Gradle + spot check
       # Initial gradle configuration, install dependencies, check formatting, etc
       run: ./gradlew spotlessCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 
 env:
   ANDROID_HOME: "/home/runner/tools/android-sdk"
-  ANDROID_SDK_TOOLS: "6514223_latest"
+  ANDROID_SDK_TOOLS: "6609375_latest"
 
 jobs:
   build:


### PR DESCRIPTION
Some issues that I found, but none of them are blocking:

It seems like you need to install `patcher;v4` otherwise AGP will fail and say that no license is accepted (see failing build of first commit) https://issuetracker.google.com/issues/160361319 

AGP will download the old `tools` package, even though we already have it's replacement https://issuetracker.google.com/issues/159376117

AGP will download `platform-tools` and `emulator` even if no tasks needing them are executed. Also potentially `build-tools` but that might be more tricky unless aidl and renderscript are explicitly disabled https://issuetracker.google.com/issues/159363772