### PR TITLE
Make cacheZones() friendlier to android API blacklists

### DIFF
--- a/ticktock-android/tests/src/androidTest/java/dev/zacsweers/ticktock/android/tests/LazyZoneRulesTest.java
+++ b/ticktock-android/tests/src/androidTest/java/dev/zacsweers/ticktock/android/tests/LazyZoneRulesTest.java
@@ -18,7 +18,6 @@ package dev.zacsweers.ticktock.android.tests;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import dev.zacsweers.ticktock.android.lazyzonerules.AndroidLazyZoneRules;
-import dev.zacsweers.ticktock.runtime.EagerZoneRulesLoading;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,7 +28,7 @@ public final class LazyZoneRulesTest {
   public void init() {
     AndroidLazyZoneRules.init(ApplicationProvider.getApplicationContext());
     TestLogger logger = TestLogger.createAndInstall();
-    EagerZoneRulesLoading.cacheZones();
+    TestEagerZoneRules.cacheZonesAndAssertLoaded();
     logger.assertDidLog();
   }
 }

--- a/ticktock-android/tests/src/androidTest/java/dev/zacsweers/ticktock/android/tests/TestEagerZoneRules.java
+++ b/ticktock-android/tests/src/androidTest/java/dev/zacsweers/ticktock/android/tests/TestEagerZoneRules.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.zacsweers.ticktock.jvm.tests;
+package dev.zacsweers.ticktock.android.tests;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Collections.synchronizedSet;

--- a/ticktock-android/tests/src/androidTest/java/dev/zacsweers/ticktock/android/tests/TzdbZoneRulesTest.java
+++ b/ticktock-android/tests/src/androidTest/java/dev/zacsweers/ticktock/android/tests/TzdbZoneRulesTest.java
@@ -18,7 +18,6 @@ package dev.zacsweers.ticktock.android.tests;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import dev.zacsweers.ticktock.android.tzdb.AndroidTzdbZoneRules;
-import dev.zacsweers.ticktock.runtime.EagerZoneRulesLoading;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -29,7 +28,7 @@ public final class TzdbZoneRulesTest {
   public void init() {
     AndroidTzdbZoneRules.init(ApplicationProvider.getApplicationContext());
     TestLogger logger = TestLogger.createAndInstall();
-    EagerZoneRulesLoading.cacheZones();
+    TestEagerZoneRules.cacheZonesAndAssertLoaded();
     logger.assertDidLog();
   }
 }

--- a/ticktock-jvm/tests/src/test/java/dev/zacsweers/ticktock/jvm/tests/LazyZoneRulesTest.java
+++ b/ticktock-jvm/tests/src/test/java/dev/zacsweers/ticktock/jvm/tests/LazyZoneRulesTest.java
@@ -16,7 +16,6 @@
 package dev.zacsweers.ticktock.jvm.tests;
 
 import dev.zacsweers.ticktock.jvm.lazyzonerules.JvmLazyZoneRules;
-import dev.zacsweers.ticktock.runtime.EagerZoneRulesLoading;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,7 +27,7 @@ public final class LazyZoneRulesTest {
   public void init() {
     JvmLazyZoneRules.init();
     TestLogger logger = TestLogger.createAndInstall();
-    EagerZoneRulesLoading.cacheZones();
+    TestEagerZoneRules.cacheZonesAndAssertLoaded();
     logger.assertDidLog();
   }
 }

--- a/ticktock-jvm/tests/src/test/java/dev/zacsweers/ticktock/jvm/tests/TestEagerZoneRules.java
+++ b/ticktock-jvm/tests/src/test/java/dev/zacsweers/ticktock/jvm/tests/TestEagerZoneRules.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Zac Sweers & Gabriel Ittner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.zacsweers.ticktock.jvm.tests;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Collections.synchronizedSet;
+
+import dev.zacsweers.ticktock.runtime.EagerZoneRulesLoading;
+import dev.zacsweers.ticktock.runtime.TickTockPlugins;
+import dev.zacsweers.ticktock.runtime.ZoneDataProvider;
+import java.time.zone.ZoneRulesProvider;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+final class TestEagerZoneRules {
+  private TestEagerZoneRules() {}
+
+  /** Calls {@link EagerZoneRulesLoading#cacheZones()} and returns the loaded zone IDs. */
+  static void cacheZonesAndAssertLoaded() {
+    Supplier<ZoneDataProvider> currentSupplier = TickTockPlugins.getZoneDataProvider();
+    ZoneDataProvider currentProvider = currentSupplier.get();
+    Set<String> loadedZones = synchronizedSet(new LinkedHashSet<>());
+    ZoneDataProvider newProvider =
+        zoneId -> {
+          loadedZones.add(zoneId);
+          return currentProvider.getZoneRules(zoneId);
+        };
+    Supplier<ZoneDataProvider> newSupplier = () -> newProvider;
+    TickTockPlugins.setZoneDataProvider(newSupplier);
+    EagerZoneRulesLoading.cacheZones();
+    assertThat(loadedZones).containsExactlyElementsIn(ZoneRulesProvider.getAvailableZoneIds());
+  }
+}

--- a/ticktock-jvm/tests/src/test/java/dev/zacsweers/ticktock/jvm/tests/TzdbZoneRulesTest.java
+++ b/ticktock-jvm/tests/src/test/java/dev/zacsweers/ticktock/jvm/tests/TzdbZoneRulesTest.java
@@ -16,7 +16,6 @@
 package dev.zacsweers.ticktock.jvm.tests;
 
 import dev.zacsweers.ticktock.jvm.tzdb.JvmTzdbZoneRules;
-import dev.zacsweers.ticktock.runtime.EagerZoneRulesLoading;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,7 +27,7 @@ public final class TzdbZoneRulesTest {
   public void init() {
     JvmTzdbZoneRules.init();
     TestLogger logger = TestLogger.createAndInstall();
-    EagerZoneRulesLoading.cacheZones();
+    TestEagerZoneRules.cacheZonesAndAssertLoaded();
     logger.assertDidLog();
   }
 }

--- a/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/EagerZoneRulesLoading.java
+++ b/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/EagerZoneRulesLoading.java
@@ -29,7 +29,7 @@ public final class EagerZoneRulesLoading {
   public static void cacheZones() {
     try {
       ZoneId.systemDefault().getRules();
-      Set<String> zoneIds = ZoneRulesProvider.getAvailableZoneIds();
+      Set<String> zoneIds = ZoneId.getAvailableZoneIds();
       if (zoneIds.isEmpty()) {
         throw new IllegalStateException("No zone ids available!");
       }

--- a/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/EagerZoneRulesLoading.java
+++ b/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/EagerZoneRulesLoading.java
@@ -16,7 +16,6 @@
 package dev.zacsweers.ticktock.runtime;
 
 import java.time.ZoneId;
-import java.time.zone.ZoneRulesProvider;
 import java.util.Set;
 
 /** Utilities for eager zone rule caching. */
@@ -34,7 +33,7 @@ public final class EagerZoneRulesLoading {
         throw new IllegalStateException("No zone ids available!");
       }
       for (String zoneId : zoneIds) {
-        ZoneRulesProvider.getRules(zoneId, true);
+        ZoneId.of(zoneId).getRules();
       }
     } catch (NoSuchMethodError e) {
       // If targeting a newer Android device or minSdk 26, this will fail because ZoneRulesProvider

--- a/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/EagerZoneRulesLoading.java
+++ b/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/EagerZoneRulesLoading.java
@@ -26,19 +26,13 @@ public final class EagerZoneRulesLoading {
    * ZoneId#systemDefault()} which is the one most likely to be used.
    */
   public static void cacheZones() {
-    try {
-      ZoneId.systemDefault().getRules();
-      Set<String> zoneIds = ZoneId.getAvailableZoneIds();
-      if (zoneIds.isEmpty()) {
-        throw new IllegalStateException("No zone ids available!");
-      }
-      for (String zoneId : zoneIds) {
-        ZoneId.of(zoneId).getRules();
-      }
-    } catch (NoSuchMethodError e) {
-      // If targeting a newer Android device or minSdk 26, this will fail because ZoneRulesProvider
-      // is a strangely hidden API: https://issuetracker.google.com/issues/159421054
-      System.err.println("Could not eagerly initialize zone rules: " + e.getMessage());
+    ZoneId.systemDefault().getRules();
+    Set<String> zoneIds = ZoneId.getAvailableZoneIds();
+    if (zoneIds.isEmpty()) {
+      throw new IllegalStateException("No zone ids available!");
+    }
+    for (String zoneId : zoneIds) {
+      ZoneId.of(zoneId).getRules();
     }
   }
 }

--- a/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/TickTockPlugins.java
+++ b/ticktock-runtime/src/main/java/dev/zacsweers/ticktock/runtime/TickTockPlugins.java
@@ -47,7 +47,7 @@ public final class TickTockPlugins {
   }
 
   /** @return the value for handling {@link ZoneIdsProvider}. */
-  static Supplier<ZoneIdsProvider> getZoneIdsProvider() {
+  public static Supplier<ZoneIdsProvider> getZoneIdsProvider() {
     return zoneIdsProvider;
   }
 
@@ -60,7 +60,7 @@ public final class TickTockPlugins {
   }
 
   /** @return the value for handling {@link ZoneDataProvider}. */
-  static Supplier<ZoneDataProvider> getZoneDataProvider() {
+  public static Supplier<ZoneDataProvider> getZoneDataProvider() {
     return zoneDataProvider;
   }
 
@@ -73,7 +73,7 @@ public final class TickTockPlugins {
   }
 
   /** @return the value for handling {@link TickTockLogger}. */
-  static Supplier<TickTockLogger> getLogger() {
+  public static Supplier<TickTockLogger> getLogger() {
     return loggerSupplier;
   }
 


### PR DESCRIPTION
We can use `ZoneId` APIs rather than `ZoneRulesProvider` to avoid problems with newer API versions. This also locks this down with new test helpers to confirm we've loaded the available zones