### PR TITLE
change shell used to run script

### DIFF
--- a/regenerateData.sh
+++ b/regenerateData.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ./gradlew clean
 ./gradlew :ticktock-jvm:lazyzonerules:generateLazyZoneRules

--- a/regenerateData.sh
+++ b/regenerateData.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/sh
 
 ./gradlew clean
 ./gradlew :ticktock-jvm:lazyzonerules:generateLazyZoneRules


### PR DESCRIPTION
Seems like zsh isn't available anymore https://github.com/ZacSweers/ticktock/runs/1759529913?check_suite_focus=true Changed it to bash which is used in the Android SDK script