### PR TITLE
Update AGP and kotlin to fix #58

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,18 +16,18 @@
 buildscript {
   dependencies {
     // Needs to go first, else gradle's forced older version version takes precedence
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
     classpath("dev.zacsweers.ticktock:ticktock-gradle-plugin:${findProperty("VERSION_NAME")}")
-    classpath("com.android.tools.build:gradle:7.0.3")
+    classpath("com.android.tools.build:gradle:7.3.0")
   }
 }
 
 plugins {
-  id 'org.jetbrains.kotlin.jvm' apply false version '1.5.31'
-  id 'org.jetbrains.kotlin.kapt' apply false version '1.5.31'
+  id 'org.jetbrains.kotlin.jvm' apply false version '1.7.20'
+  id 'org.jetbrains.kotlin.kapt' apply false version '1.7.20'
   id 'com.diffplug.spotless' apply false version '5.17.0'
   id 'com.vanniktech.maven.publish' apply false version '0.18.0'
-  id 'org.jetbrains.dokka' apply false version '1.5.31'
+  id 'org.jetbrains.dokka' apply false version '1.7.20'
   id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.7.1"
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,8 +16,8 @@
 
 def versions = [
     androidTest: '1.3.0',
-    dokka: '1.5.31',
-    kotlin: '1.5.31',
+    dokka: '1.7.20',
+    kotlin: '1.7.20',
     ktlint: '0.42.1',
     spotless: '5.14.3'
 ]
@@ -57,7 +57,7 @@ def test = [
     androidOrchestrator: "androidx.test:orchestrator:${versions.androidTest}",
     compileTesting: 'com.google.testing.compile:compile-testing:0.19',
     junit: 'junit:junit:4.13.2',
-    kotlinCompileTesting: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.5',
+    kotlinCompileTesting: 'com.github.tschuchortdev:kotlin-compile-testing:1.4.9',
     okio: "com.squareup.okio:okio:3.0.0",
     truth: 'com.google.truth:truth:1.1.2',
 ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Oct 14 11:37:30 EEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,4 +40,3 @@ includeBuild("ticktock-gradle-plugin") {
     substitute(module("dev.zacsweers.ticktock:ticktock-gradle-plugin")).with(project(":"))
   }
 }
-include(":testandroid")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,3 +40,4 @@ includeBuild("ticktock-gradle-plugin") {
     substitute(module("dev.zacsweers.ticktock:ticktock-gradle-plugin")).with(project(":"))
   }
 }
+include(":testandroid")

--- a/ticktock-gradle-plugin/build.gradle.kts
+++ b/ticktock-gradle-plugin/build.gradle.kts
@@ -20,9 +20,9 @@ import java.net.URL
 plugins {
   `kotlin-dsl`
   `java-gradle-plugin`
-  kotlin("jvm") version "1.5.31"
-  kotlin("kapt") version "1.5.31"
-  id("org.jetbrains.dokka") version "1.5.31"
+  kotlin("jvm") version "1.7.20"
+  kotlin("kapt") version "1.7.20"
+  id("org.jetbrains.dokka") version "1.7.20"
   id("com.vanniktech.maven.publish") version "0.18.0"
   id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.7.1"
 }
@@ -93,7 +93,7 @@ tasks.named<DokkaTask>("dokkaHtml") {
 }
 
 dependencies {
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.5.31")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.7.20")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
   implementation("de.undercouch:gradle-download-task:4.1.1")
 }


### PR DESCRIPTION
## What's done
AGP: 7.0.3 -> 7.3.0
Kotlin: 1.5.31 -> 1.7.20

## Motivation
When consumers of ticktock-android upgrade AGP to 7.3.0, there are some issues (described in #58 )
After playing around, updating AGP and Kotlin in this repo solves the problem. A working example is in [branch](https://github.com/giangpham96/ticktock/tree/testing-example).
To be honest, I don't know what caused the original issue. Any input is welcome 
